### PR TITLE
Reset block when changing file or package.json

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,16 +46,16 @@ function App() {
     }
   }, [fileUrl]);
 
-  const block = pkgJson?.blocks.find((v) => v.entry === blockId);
+  const [block, setBlock] = useState(pkgJson?.blocks.find((v) => v.entry === blockId));
 
   useEffect(() => {
     // if we're using an old entry point that no longer exists,
     // default to the first block in the list
-    if (block) return
     const defaultBlockId = pkgJson?.blocks[0].entry;
     if (!defaultBlockId) return
     setBlockId(defaultBlockId)
-  }, [block])
+    setBlock(pkgJson?.blocks.find((v) => v.entry === defaultBlockId));
+  }, [block, pkgJson])
 
   return (
     <div style={{


### PR DESCRIPTION
We were still getting errors when the block id was changed and the blocks variable was not getting reset.