### PR TITLE
Reset block variable when id changes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,16 +46,20 @@ function App() {
     }
   }, [fileUrl]);
 
-  const block = pkgJson?.blocks.find((v) => v.entry === blockId);
+  const [block, setBlock] = useState(pkgJson?.blocks.find((v) => v.entry === blockId));
 
   useEffect(() => {
-    // if we're using an old entry point that no longer exists,
-    // default to the first block in the list
-    if (block) return
-    const defaultBlockId = pkgJson?.blocks[0].entry;
-    if (!defaultBlockId) return
-    setBlockId(defaultBlockId)
-  }, [block])
+    const entry = pkgJson?.blocks.find((v) => v.entry === blockId);
+
+    if (entry) {
+      setBlock(entry);
+    }
+    else {
+      const defaultBlockId = pkgJson?.blocks[0].entry;
+      if (!defaultBlockId) return
+      setBlockId(defaultBlockId)
+    }
+  }, [blockId, pkgJson]);
 
   return (
     <div style={{


### PR DESCRIPTION
We were still getting errors when the block id was changed and the blocks variable was not getting reset.