### PR TITLE
post error back to sandbox when `onRequestGitHubData` fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "@codesandbox/sandpack-react": "^0.13.13",
-    "@githubnext/utils": "^0.19.5",
+    "@githubnext/utils": "^0.19.6",
     "@loadable/component": "^5.15.0",
     "@octokit/rest": "^18.12.0",
     "@types/lodash.uniqueid": "^4.0.6",

--- a/src/components/production-block.tsx
+++ b/src/components/production-block.tsx
@@ -68,20 +68,21 @@ export const ProductionBlock = (props: ProductionBlockProps) => {
           /^https:\/\/\d{1,4}-\d{1,4}-\d{1,4}-sandpack\.codesandbox\.io$/
         );
         if (!source || !originRegex.test(origin)) return;
+        const window = source as Window;
         if (data.type === "github-data--request") {
           onRequestGitHubData(data.path, data.params)
             .then((res) => {
-              source.postMessage(
+              window.postMessage(
                 {
                   type: "github-data--response",
                   id: id.current,
                   data: res,
                 },
-                origin as any
+                origin
               );
             })
             .catch((e) => {
-              source.postMessage(
+              window.postMessage(
                 {
                   type: "github-data--response",
                   id: id.current,
@@ -89,7 +90,7 @@ export const ProductionBlock = (props: ProductionBlockProps) => {
                   // https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#things_that_dont_work_with_structured_clone
                   error: e instanceof Error ? e.message : e,
                 },
-                origin as any
+                origin
               );
             });
         }

--- a/src/components/production-block.tsx
+++ b/src/components/production-block.tsx
@@ -33,7 +33,6 @@ export const ProductionBlock = (props: ProductionBlockProps) => {
   const { block, contents, tree, metadata = {}, context } = props;
 
   const [bundleCode, setBundleCode] = useState<BundleCode[]>([]);
-  const sandpackWrapper = useRef<HTMLDivElement>(null);
   const id = useRef(uniqueId("sandboxed-block-"));
 
   const getContents = async () => {
@@ -118,7 +117,6 @@ export const ProductionBlock = (props: ProductionBlockProps) => {
 
   return (
     <div
-      ref={sandpackWrapper}
       style={{
         width: "100%",
         height: "100%",

--- a/src/components/production-block.tsx
+++ b/src/components/production-block.tsx
@@ -115,11 +115,6 @@ export const ProductionBlock = (props: ProductionBlockProps) => {
 
   if (!bundleCode) return null;
 
-  const filesWithConfig = {
-    ...files,
-    "/sandbox.config.json": JSON.stringify({ infiniteLoopProtection: false }),
-  };
-
   return (
     <div
       ref={sandpackWrapper}
@@ -133,7 +128,7 @@ export const ProductionBlock = (props: ProductionBlockProps) => {
         template="react"
         customSetup={{
           dependencies: {},
-          files: filesWithConfig,
+          files,
         }}
         autorun
       >


### PR DESCRIPTION
When `onRequestGitHubData` fails, post an error message to the calling context, to be handled by  https://github.com/githubnext/utils/pull/12

(PRs for `blocks-examples`, `blocks-marketplace`, `blocks` forthcoming)
