### PR TITLE
pass PAT from environment to `onRequestGitHubData`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ interface BlockProps {
   onRequestGitHubData: (
     // this is any GET endpoint in the GitHub API:
     // https://docs.github.com/en/rest/overview/endpoints-available-for-github-apps
+    // e.g. `/repos/{owner}/{repo}/contributors`
     path: string,
     params: Record<string, any>
   ) => Promise<any>;
@@ -157,6 +158,11 @@ A few caveats and callouts:
 - Blocks have access to [GitHub Primer CSS styles](https://primer.style/css/)
 - You can use both third-party _and_ relative imports in your Block code! Simply put, feel free to install any dependencies from NPM, or import a local JS/CSS file and it should be included in the final bundle.
 - Your Block entry file **must have the Block component as its default export**. If it does not, bad things will happen.
+- To make authenticated requests to the GitHub API, create a [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) and pass it when you start the dev server:
+
+```
+VITE_GITHUB_PAT=${your personal access token} yarn dev
+```
 
 ##### Relevant repos
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ A few caveats and callouts:
 - Blocks have access to [GitHub Primer CSS styles](https://primer.style/css/)
 - You can use both third-party _and_ relative imports in your Block code! Simply put, feel free to install any dependencies from NPM, or import a local JS/CSS file and it should be included in the final bundle.
 - Your Block entry file **must have the Block component as its default export**. If it does not, bad things will happen.
-- To make authenticated requests to the GitHub API, create a [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) and pass it when you start the dev server:
+- To make authenticated requests to the GitHub API, create a [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) (with `repo` scope) and pass it when you start the dev server:
 
 ```
 VITE_GITHUB_PAT=${your personal access token} yarn dev

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ A few caveats and callouts:
 VITE_GITHUB_PAT=${your personal access token} yarn dev
 ```
 
+or put it in your [`.env`](https://vitejs.dev/guide/env-and-mode.html#env-files) file in the project root directory.
+
 ##### Relevant repos
 
 [Blocks examples](https://github.com/githubnext/blocks-examples)

--- a/src/components/local-block.tsx
+++ b/src/components/local-block.tsx
@@ -8,6 +8,8 @@ import {
   onRequestGitHubData as onRequestGitHubDataFetch,
 } from "@githubnext/utils";
 
+const PAT = import.meta.env.VITE_GITHUB_PAT;
+
 interface Block {
   id: string;
   type: string;
@@ -87,7 +89,11 @@ export const LocalBlock = (props: LocalBlockProps) => {
       },
       "*"
     );
-    const data = await onRequestGitHubDataFetch(path, params);
+    const data = await onRequestGitHubDataFetch(
+      path,
+      params,
+      PAT ? `Bearer ${PAT}` : undefined
+    );
     window.postMessage(
       {
         type: "github-data--response",

--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -30,9 +30,7 @@ async function getFolderContent(
   const apiUrl = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`;
 
   const res = await fetch(apiUrl, {
-    headers: {
-      Accept: `Bearer ${PAT}`,
-    },
+    headers: PAT ? { Authorization: `Bearer ${PAT}` } : {},
   });
   const { tree: rawTree } = await res.json();
 
@@ -77,16 +75,7 @@ export async function getFileContent(
   const branch = fileRef || "HEAD";
 
   const apiUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${path}`;
-  const res = await fetch(
-    apiUrl,
-    PAT
-      ? {
-          headers: {
-            Accept: `Bearer ${PAT}`,
-          },
-        }
-      : {}
-  );
+  const res = await fetch(apiUrl);
 
   if (res.status !== 200) throw new Error("Something bad happened");
 


### PR DESCRIPTION
Pass a personal access token from the process environment to `onRequestGitHubData`, to make testing blocks that call the GitHub API easier. (I tested this with https://github.com/mattrothenberg/codeowners-block)

I also fixed a couple other uses of PATs: I don't think `Accept: Bearer ${PAT}` is valid, so I replaced it with `Authorization: Bearer ${PAT}`; but `Authorization` headers are rejected by `raw.githubusercontent.com` because of CORS so I dropped that one. If I've misunderstood things please let me know!
