### PR TITLE
fix: pass PAT without bearer prefix

### DIFF
--- a/src/components/local-block.tsx
+++ b/src/components/local-block.tsx
@@ -92,7 +92,7 @@ export const LocalBlock = (props: LocalBlockProps) => {
     const data = await onRequestGitHubDataFetch(
       path,
       params,
-      PAT ? `Bearer ${PAT}` : undefined
+      PAT ? `${PAT}` : undefined
     );
     window.postMessage(
       {


### PR DESCRIPTION
I noticed that all of my requests were failing when I provided a PAT.

Upon closer inspection, we already apply the `token` prefix to our authentication header in `@githubnext/utils`, https://github.com/githubnext/utils/blob/main/src/lib/on-request-github-data.ts#L12. As such, this `Bearer` prefix seems unnecessary