### PR TITLE
chore: Use setup-node action to cache dependencies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,10 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: yarn
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Compile assets
         run: yarn build


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Details

Updated workflows to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v3` or newer has caching **built-in**.

### AS-IS

```yml
- name: Checkout code
  uses: actions/checkout@v3

- name: Install dependencies
  run: yarn install
```

### TO-BE

```yml
- name: Checkout code
  uses: actions/checkout@v3

- name: Set up Node.js
  uses: actions/setup-node@v3
  with:
    node-version: 18.x
    cache: yarn

- name: Install dependencies
  run: yarn install --immutable
```

> It’s literally a one line change to pass the `cache: yarn` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)
